### PR TITLE
add `new_at` method for Executor

### DIFF
--- a/src/program/executor.rs
+++ b/src/program/executor.rs
@@ -54,10 +54,20 @@ pub struct Executor {
 }
 
 impl Executor {
-    /// Create a new Executor
+    /// Create a new Executor with a default Ollama instance.
     pub fn new(model: Model) -> Self {
-        let llm = Ollama::default();
-        Executor { model, llm }
+        Self {
+            model,
+            llm: Ollama::default(),
+        }
+    }
+
+    /// Create a new Executor with a given Ollama instance
+    pub fn new_at(model: Model, host: &str, port: u16) -> Self {
+        Self {
+            model,
+            llm: Ollama::new(host, port),
+        }
     }
 
     /// Executes the workflow

--- a/src/program/executor.rs
+++ b/src/program/executor.rs
@@ -62,7 +62,7 @@ impl Executor {
         }
     }
 
-    /// Create a new Executor with a given Ollama instance
+    /// Create a new Executor for an Ollama instance at a specific host and port.
     pub fn new_at(model: Model, host: &str, port: u16) -> Self {
         Self {
             model,


### PR DESCRIPTION
This allows us to connect to an Ollama instance at a given host & port.