### PR TITLE
chore: Workflow as reference

### DIFF
--- a/examples/execute_workflow.rs
+++ b/examples/execute_workflow.rs
@@ -11,7 +11,7 @@ async fn main() {
     let workflow = Workflow::new_from_json("./workflows/search.json").unwrap();
     let mut memory = ProgramMemory::new();
     let input = Entry::try_value_or_str("How would does reiki work?");
-    let return_value = exe.execute(Some(&input), workflow, &mut memory).await;
+    let return_value = exe.execute(Some(&input), &workflow, &mut memory).await;
     match return_value {
         Ok(value) => println!("{}", value),
         Err(err) => eprintln!("Error: {:?}", err),

--- a/src/program/executor.rs
+++ b/src/program/executor.rs
@@ -80,7 +80,7 @@ impl Executor {
     pub async fn execute(
         &self,
         input: Option<&Entry>,
-        workflow: Workflow,
+        workflow: &Workflow,
         memory: &mut ProgramMemory,
     ) -> Result<String, ExecutionError> {
         let config = workflow.get_config();

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -33,7 +33,7 @@ macro_rules! workflow_test {
             let workflow = Workflow::new_from_json($workflow).unwrap();
             let mut memory = ProgramMemory::new();
             let input = Entry::try_value_or_str($input);
-            if let Err(e) = exe.execute(Some(&input), workflow, &mut memory).await {
+            if let Err(e) = exe.execute(Some(&input), &workflow, &mut memory).await {
                 log::error!("Execution failed: {}", e);
             };
         }
@@ -44,7 +44,7 @@ macro_rules! workflow_test {
             let exe = setup_test($model).await;
             let workflow = Workflow::new_from_json($workflow).unwrap();
             let mut memory = ProgramMemory::new();
-            if let Err(e) = exe.execute(None, workflow, &mut memory).await {
+            if let Err(e) = exe.execute(None, &workflow, &mut memory).await {
                 log::error!("Execution failed: {}", e);
             };
         }


### PR DESCRIPTION
This small edit will save so many lives, especially because `Clone` is not implemented in the workflow so it cant be moved around easily, and must be consumed by executor as is.