### PR TITLE
fix: gemini error reporters

### DIFF
--- a/src/api_interface/gem_api.rs
+++ b/src/api_interface/gem_api.rs
@@ -5,7 +5,7 @@ use ollama_rs::{
 };
 use reqwest::Client;
 use serde_json::{json, Value};
-use std::sync::Arc;
+use std::{error::Error, sync::Arc};
 
 pub struct GeminiExecutor {
     model: String,
@@ -80,7 +80,18 @@ impl GeminiExecutor {
             .json(&body)
             .send()
             .await
-            .map_err(|e| OllamaError::from(format!("Gemini API request failed: {}", e)))?;
+            .map_err(|e| {
+                OllamaError::from(format!("Gemini API request failed: {:?}", e.source()))
+            })?;
+
+        // check status
+        if let Err(e) = response.error_for_status_ref() {
+            return Err(OllamaError::from(format!(
+                "Gemini API request failed with status {}: {:?}",
+                response.status(),
+                e.source()
+            )));
+        }
 
         let response_body: Value = response.json().await.map_err(|e| {
             OllamaError::from(format!("Failed to parse Gemini API response: {}", e))
@@ -167,7 +178,27 @@ impl GeminiExecutor {
             .json(&body)
             .send()
             .await
-            .map_err(|e| OllamaError::from(format!("Gemini API request failed: {:?}", e)))?;
+            .map_err(|e| {
+                OllamaError::from(format!("Gemini API request failed: {:?}", e.source()))
+            })?;
+
+        // check status
+        if let Err(e) = response.error_for_status_ref() {
+            return Err(OllamaError::from(format!(
+                "Gemini API request failed with status {}: {:?}",
+                response.status(),
+                e.source()
+            )));
+        }
+
+        // check status
+        if let Err(e) = response.error_for_status_ref() {
+            return Err(OllamaError::from(format!(
+                "Gemini API request failed with status {}: {:?}",
+                response.status(),
+                e.source()
+            )));
+        }
 
         let response_body: Value = response.json().await.map_err(|e| {
             OllamaError::from(format!("Failed to parse Gemini API response: {:?}", e))

--- a/src/api_interface/gem_api.rs
+++ b/src/api_interface/gem_api.rs
@@ -191,15 +191,6 @@ impl GeminiExecutor {
             )));
         }
 
-        // check status
-        if let Err(e) = response.error_for_status_ref() {
-            return Err(OllamaError::from(format!(
-                "Gemini API request failed with status {}: {:?}",
-                response.status(),
-                e.source()
-            )));
-        }
-
         let response_body: Value = response.json().await.map_err(|e| {
             OllamaError::from(format!("Failed to parse Gemini API response: {:?}", e))
         })?;


### PR DESCRIPTION
Uses `e.source()` instead of `e` in error messages within `gem_api` to hide URL which has the API Key. If status code is non `2XX`, returns a message with the code as well.