### PR TITLE
fix: added reasoning output for OpenRouter

### DIFF
--- a/src/api_interface/gem_api.rs
+++ b/src/api_interface/gem_api.rs
@@ -28,7 +28,7 @@ impl GeminiExecutor {
     pub async fn generate_text(
         &self,
         input: Vec<MessageInput>,
-        schema: &Option<String>,
+        schema: Option<&String>,
     ) -> Result<String, OllamaError> {
         let url = format!(
             "https://generativelanguage.googleapis.com/v1beta/models/{}:generateContent?key={}",

--- a/src/api_interface/openai_api.rs
+++ b/src/api_interface/openai_api.rs
@@ -24,7 +24,7 @@ impl OpenAIExecutor {
     pub async fn generate_text(
         &self,
         input: Vec<MessageInput>,
-        schema: &Option<String>,
+        schema: Option<&String>,
     ) -> Result<String, OllamaError> {
         let messages: Vec<ChatMessage> = input
             .into_iter()

--- a/src/program/executor.rs
+++ b/src/program/executor.rs
@@ -570,13 +570,15 @@ impl Executor {
                 let api_key = std::env::var("OPENAI_API_KEY").expect("$OPENAI_API_KEY is not set");
 
                 let openai_executor = OpenAIExecutor::new(self.model.to_string(), api_key.clone());
-                openai_executor.generate_text(input, schema).await?
+                openai_executor
+                    .generate_text(input, schema.as_ref())
+                    .await?
             }
             ModelProvider::Gemini => {
                 let api_key = std::env::var("GEMINI_API_KEY").expect("$GEMINI_API_KEY is not set");
                 let max_tokens = config.max_tokens.unwrap_or(800);
                 let executor = GeminiExecutor::new(self.model.to_string(), api_key, max_tokens);
-                executor.generate_text(input, schema).await?
+                executor.generate_text(input, schema.as_ref()).await?
             }
             ModelProvider::OpenRouter => {
                 let api_key =
@@ -584,7 +586,9 @@ impl Executor {
 
                 let openai_executor =
                     OpenRouterExecutor::new(self.model.to_string(), api_key.clone());
-                openai_executor.generate_text(input, schema).await?
+                openai_executor
+                    .generate_text(input, schema.as_ref(), self.model.has_reasoning())
+                    .await?
             }
             ModelProvider::VLLM => {
                 let executor =
@@ -730,8 +734,8 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    #[ignore = "run this manually"]
-    async fn test_pull() {
+    #[ignore = "requires Ollama"]
+    async fn test_ollama_pull() {
         let executor = Executor::new(Model::Phi3_5Mini);
         let locals = executor
             .list_local_models()


### PR DESCRIPTION
Resolves #39 by adding a `has_reasoning` function to `Model` enum and using that to ask for reasoning output from OpenRouter models. If there is a reasoning data, the output it will be returned as:

```xml
<think>
{reasoning}
</think>

{content}
```

Additionally:
- Some minor utility functions to `model` as well
- Change schema type from `&Option<T>` to `Option<&T>` (more idiomatic)